### PR TITLE
[FE 세준&현식] 2-1 페이지 구현 완료

### DIFF
--- a/mycar/package-lock.json
+++ b/mycar/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "classnames": "^2.5.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -1400,6 +1401,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2028,6 +2035,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4555,6 +4571,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.3.tgz",
+      "integrity": "sha512-EezYymLY6Guk/zLQ2vRA8WvdUhWFEj5fcE3RfWihhxXBW7+cd1LsIiA3lmx+KCmneAGQuyBv820o44L2+TtkSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.3.tgz",
+      "integrity": "sha512-qQGTE+77hleBzv9SIUIkGRvuFBQGagW+TQKy53UTZAO/3+YFNBYvRsNIZ1GT17yHbc63FylMOdS+m3oUriF1GA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4797,6 +4853,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5334,6 +5396,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/mycar/package-lock.json
+++ b/mycar/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "classnames": "^2.5.1",
+        "motion": "^12.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.3"
@@ -2869,6 +2870,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.0.0.tgz",
+      "integrity": "sha512-S3V6UlZUa6km3TWJS5wH5hJs0RBgvLo2MYWINA2RwG+T/xGGKweJwEn38AtlDCjq9k70QFk7Op67jm8TAOb4qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.0.0",
+        "motion-utils": "^12.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3926,6 +3954,47 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.0.0.tgz",
+      "integrity": "sha512-nb9sDjfnq+JpBUPBC08ZGtdDhniTfNdtBhC/PtQKZWfzOUQyGHiAoo6JSjpc+ljkBaHapMypzvzr/07/kPVh0g==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.0.0.tgz",
+      "integrity": "sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.0.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.0.0.tgz",
+      "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5396,6 +5465,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",

--- a/mycar/package.json
+++ b/mycar/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "classnames": "^2.5.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/mycar/package.json
+++ b/mycar/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
+    "motion": "^12.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.3"

--- a/mycar/src/App.jsx
+++ b/mycar/src/App.jsx
@@ -1,37 +1,17 @@
-import { useState } from 'react';
 import './App.css';
-import CarThumbnail from './components/CarThumbnail';
-import ModelSelect from './components/ModelSelect';
-import { carThumbnails, Category } from './datas/carInfo';
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import SelectModel from './pages/SelectModel';
+import SelectOption from './pages/SelectOption';
 
 function App() {
-  const [category, setCate] = useState(Category.EV);
 
   return (
-    <div className='h-dvh w-dvw min-w-96'>
-      <header className='h-2/5 bg-primary p-10 pb-0'>
-        <div className='w-full h-full bg-secondary flex flex-col justify-center items-center gap-8'>
-          <h1 className='text-6xl font-bold'>내 차 만들기</h1>
-          <h1 className='text-base font-normal'>
-            내가 타고 싶은 나만의 차를 만들어 보세요.
-          </h1>
-        </div>
-      </header>
-      <main className='h-full w-full flex flex-col items-center overflow-auto'>
-        <ModelSelect setCate={setCate} category={category} />
-        <hr className='h-1 w-full'></hr>
-        <div className='grid grid-cols-2 md:grid-cols-4'>
-          {carThumbnails.filter((car) => car.carType === category).map((car, i) => (
-            <CarThumbnail
-              key={i}
-              imageLink={car.imageLink}
-              carName={car.carName}
-              carPrice={car.carPrice}
-            />
-          ))}
-        </div>
-      </main>
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/" element={<SelectModel />} />
+        <Route path="/select-option/:carName" element={<SelectOption />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/mycar/src/components/CarThumbnail.jsx
+++ b/mycar/src/components/CarThumbnail.jsx
@@ -1,9 +1,9 @@
-export default function CarThubnail(props) {
+export default function CarThubnail({imageLink, carName, carPrice, onClick}) {
   return (
-    <div className='flex flex-col justify-center items-center'>
-      <img className='' src={props.imageLink}></img>
-      <h3>{props.carName}</h3>
-      <p>{props.carPrice}</p>
+    <div className='flex flex-col justify-center items-center' onClick={onClick}>
+      <img src={imageLink}></img>
+      <h3 className="font-bold">{carName}</h3>
+      <p>{carPrice}</p>
     </div>
   );
 }

--- a/mycar/src/components/ModelCard.jsx
+++ b/mycar/src/components/ModelCard.jsx
@@ -5,18 +5,20 @@ export default function ModelCard({ carModel }) {
     "https://www.hyundai.com/contents/vr360/CN17/trim/RB-USP-003.png"
   ]
   return (
-    <div className="flex flex-col">
-      <div className="">{carModel.modelName}</div>
-      <div className="">{carModel.price}</div>
-      <img className="" src={carModel.imageSrc} />
-      <div className="flex">
+    <div className="flex flex-col bg-thirdary p-6">
+      <div className=" text-xl font-bold">{carModel.modelName}</div>
+      <div className=" text-lg font-bold">{carModel.price}</div>
+      <img className=" mt-10" src={carModel.imageSrc} />
+      <div className=" w-full flex justify-around my-10">
         {optionImageList.map((optionImage, i) => {
           return (
-            <img key={i} src={optionImage} />
+            <img key={i} 
+            className=" w-1/4"
+            src={optionImage} />
           )
         })}
       </div>
-      <button className="">내 차 만들기</button>
+      <button className=" bg-buttonBlue  text-white font-normal py-3 ">내 차 만들기</button>
     </div>
   )
 }

--- a/mycar/src/components/ModelCard.jsx
+++ b/mycar/src/components/ModelCard.jsx
@@ -1,0 +1,22 @@
+export default function ModelCard({ carModel }) {
+  const optionImageList = [
+    "https://www.hyundai.com/contents/vr360/CN17/trim/RB-USP-001.png",
+    "https://www.hyundai.com/contents/vr360/CN17/trim/RB-USP-002.png",
+    "https://www.hyundai.com/contents/vr360/CN17/trim/RB-USP-003.png"
+  ]
+  return (
+    <div className="flex flex-col">
+      <div className="">{carModel.modelName}</div>
+      <div className="">{carModel.price}</div>
+      <img className="" src={carModel.imageSrc} />
+      <div className="flex">
+        {optionImageList.map((optionImage, i) => {
+          return (
+            <img key={i} src={optionImage} />
+          )
+        })}
+      </div>
+      <button className="">내 차 만들기</button>
+    </div>
+  )
+}

--- a/mycar/src/components/ModelCard.jsx
+++ b/mycar/src/components/ModelCard.jsx
@@ -1,11 +1,14 @@
-export default function ModelCard({ carModel }) {
+export default function ModelCard({ carModel, cardWidth }) {
   const optionImageList = [
     "https://www.hyundai.com/contents/vr360/CN17/trim/RB-USP-001.png",
     "https://www.hyundai.com/contents/vr360/CN17/trim/RB-USP-002.png",
     "https://www.hyundai.com/contents/vr360/CN17/trim/RB-USP-003.png"
   ]
   return (
-    <div className="flex flex-col bg-thirdary p-6">
+    <div
+      className='flex flex-col bg-thirdary p-6 flex-shrink-0'
+      style={{width: cardWidth - 21}} // 카드 간의 gap만큼 빼준 값
+    >
       <div className=" text-xl font-bold">{carModel.modelName}</div>
       <div className=" text-lg font-bold">{carModel.price}</div>
       <img className=" mt-10" src={carModel.imageSrc} />

--- a/mycar/src/components/ModelCard.jsx
+++ b/mycar/src/components/ModelCard.jsx
@@ -21,7 +21,10 @@ export default function ModelCard({ carModel, cardWidth }) {
           )
         })}
       </div>
-      <button className=" bg-buttonBlue  text-white font-normal py-3 ">내 차 만들기</button>
+      <button 
+        className=" bg-buttonBlue  text-white font-normal py-3 "
+        onClick={()=>{}}
+      >내 차 만들기</button>
     </div>
   )
 }

--- a/mycar/src/components/ModelList.jsx
+++ b/mycar/src/components/ModelList.jsx
@@ -8,7 +8,7 @@ export default function ModelList({ carName }) {
     const elementRef = useRef(null);
 
     function searchModels(modelName) {
-        const carModels = carDetailModels.find((carModel)=>carModel.carName===modelName).detailModels;
+        const carModels = carDetailModels.find((carModel) => carModel.carName === modelName).detailModels;
         return carModels;
     }
 
@@ -33,12 +33,13 @@ export default function ModelList({ carName }) {
 
     const models = searchModels(carName);
     let cardPerPage = 4;
+    const totalPageCount = Math.ceil(models.length / cardPerPage);
 
     return (
         <div ref={elementRef} className="h-full relative flex flex-col gap-7  my-8 mx-20 overflow-hidden">
             <div className="absolute left-0 top-0">전체모델({models.length})</div>
             <div className="flex gap-2 justify-center items-center">
-                {Array.from({ length: Math.ceil(models.length / cardPerPage) }).map((_, index) => (
+                {Array.from({ length: totalPageCount }).map((_, index) => (
                     <div
                         key={index}
                         className={`w-3 h-3 rounded-full ${index === pageNum ? "bg-blue-500" : "bg-gray-300"
@@ -47,14 +48,20 @@ export default function ModelList({ carName }) {
                     ></div>
                 ))}
             </div>
-            <div className='flex gap-x-7 items-center transform transition duration-300 ease-in-out'
-                style={{ transform: `translateX(${-(rectWidth + 28) * pageNum}px)` }}>
-                {models.map((carModel, i) => {
-                    return (
-                        <ModelCard key={i} carModel={carModel} cardWidth={rectWidth / cardPerPage} />
-                    )
-                })}
+            <div className='relative'>
+                <div className='flex gap-x-7 items-center transform transition duration-300 ease-in-out'
+                    style={{ transform: `translateX(${-(rectWidth + 28) * pageNum}px)` }}>
+                    {models.map((carModel, i) => {
+                        return (
+                            <ModelCard key={i} carModel={carModel} cardWidth={rectWidth / cardPerPage} />
+                        )
+                    })}
+                </div>
+                <button className='w-10 h-10 absolute left-0 top-1/2 -translate-y-1/2 items-center bg-black opacity-30 text-white' onClick={() => setPageNum((prev) => prev > 0 ? prev - 1 : prev)}>{'<'}</button>
+                <button className='w-10 h-10 absolute right-0 top-1/2 -translate-y-1/2 items-center bg-black opacity-30 text-white' onClick={() => setPageNum((prev) => prev < totalPageCount - 1 ? prev + 1 : prev)}>{'>'}</button>
             </div>
+            <p className="text-sm opacity-50">* 표시된 가격은 세제혜택 반영 전 금액으로 견적 완료 시 세제혜택이 적용된 금액 확인이 가능합니다.<br />
+                * 모델별 차량 이미지는 참고용 예시로 실제와 다를 수 있습니다.</p>
         </div>
     )
 }

--- a/mycar/src/components/ModelList.jsx
+++ b/mycar/src/components/ModelList.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { carDetailModels } from "../datas/carDetailModel";
+import ModelCard from "./ModelCard";
+
+export default function ModelList({carName}) {
+    const [pageNum, setPageNum] = useState(0);
+    
+    function searchModels(modelName) {
+        console.log(modelName);
+        const carModels = carDetailModels.find((carModel)=>carModel.carName===modelName).detailModels
+        return carModels;
+    }
+
+    const models = searchModels(carName);
+
+    return (
+        <div className="relative flex flex-col ">
+            <div className="absolute left-0 top-0">전체모델({ })</div>
+            <div className="flex gap-2 justify-center items-center">
+                {Array.from({ length: Math.ceil(models.length/4) }).map((_, index) => (
+                    <div
+                    key={index}
+                    className={`w-3 h-3 rounded-full ${
+                        index === pageNum ? "bg-blue-500" : "bg-gray-300"
+                    }`}
+                    ></div>
+                ))}
+            </div>
+            <div className="flex gap-x-7">
+                {models.map((carModel,i )=>{
+                    return (
+                        <ModelCard key={i} carModel={carModel}/>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/mycar/src/components/ModelList.jsx
+++ b/mycar/src/components/ModelList.jsx
@@ -13,19 +13,15 @@ export default function ModelList({ carName }) {
     }
 
     useEffect(() => {
-        // 초기 너비 설정 및 창 크기 조정 감지
         function updateWidth() {
             if (elementRef.current) {
                 setRectWidth(elementRef.current.offsetWidth);
             }
         }
-        // 초기 실행
         updateWidth();
 
-        // 이벤트 리스너 추가
         window.addEventListener("resize", updateWidth);
 
-        // 클린업 함수
         return () => {
             window.removeEventListener("resize", updateWidth);
         };
@@ -40,12 +36,12 @@ export default function ModelList({ carName }) {
             <div className="absolute left-0 top-0">전체모델({models.length})</div>
             <div className="flex gap-2 justify-center items-center">
                 {Array.from({ length: totalPageCount }).map((_, index) => (
-                    <div
+                    <button
                         key={index}
                         className={`w-3 h-3 rounded-full ${index === pageNum ? "bg-blue-500" : "bg-gray-300"
                             }`}
                         onClick={() => { setPageNum(index) }}
-                    ></div>
+                    ></button>
                 ))}
             </div>
             <div className='relative'>

--- a/mycar/src/components/ModelList.jsx
+++ b/mycar/src/components/ModelList.jsx
@@ -7,27 +7,29 @@ export default function ModelList({carName}) {
     
     function searchModels(modelName) {
         console.log(modelName);
-        const carModels = carDetailModels.find((carModel)=>carModel.carName===modelName).detailModels
+        const carModels = carDetailModels.find((carModel)=>carModel.carName===modelName).detailModels;
         return carModels;
     }
 
     const models = searchModels(carName);
+    let cardPerPage = 4;
 
     return (
-        <div className="relative flex flex-col ">
-            <div className="absolute left-0 top-0">전체모델({ })</div>
+        <div className=" h-full relative flex flex-col gap-7  my-8 mx-20">
+            <div className="absolute left-0 top-0">전체모델({ models.length })</div>
             <div className="flex gap-2 justify-center items-center">
-                {Array.from({ length: Math.ceil(models.length/4) }).map((_, index) => (
+                {Array.from({ length: Math.ceil(models.length/cardPerPage) }).map((_, index) => (
                     <div
                     key={index}
                     className={`w-3 h-3 rounded-full ${
                         index === pageNum ? "bg-blue-500" : "bg-gray-300"
                     }`}
+                    onClick={()=>{setPageNum(index)}}
                     ></div>
                 ))}
             </div>
-            <div className="flex gap-x-7">
-                {models.map((carModel,i )=>{
+            <div className="flex gap-x-7 justify-center items-center">
+                {models.slice(pageNum*cardPerPage, (pageNum+1)*cardPerPage).map((carModel,i )=>{
                     return (
                         <ModelCard key={i} carModel={carModel}/>
                     )

--- a/mycar/src/components/ModelList.jsx
+++ b/mycar/src/components/ModelList.jsx
@@ -1,37 +1,57 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { carDetailModels } from "../datas/carDetailModel";
 import ModelCard from "./ModelCard";
 
-export default function ModelList({carName}) {
+export default function ModelList({ carName }) {
     const [pageNum, setPageNum] = useState(0);
-    
+    const [rectWidth, setRectWidth] = useState(100);
+    const elementRef = useRef(null);
+
     function searchModels(modelName) {
-        console.log(modelName);
         const carModels = carDetailModels.find((carModel)=>carModel.carName===modelName).detailModels;
         return carModels;
     }
+
+    useEffect(() => {
+        // 초기 너비 설정 및 창 크기 조정 감지
+        function updateWidth() {
+            if (elementRef.current) {
+                setRectWidth(elementRef.current.offsetWidth);
+            }
+        }
+        // 초기 실행
+        updateWidth();
+
+        // 이벤트 리스너 추가
+        window.addEventListener("resize", updateWidth);
+
+        // 클린업 함수
+        return () => {
+            window.removeEventListener("resize", updateWidth);
+        };
+    }, []);
 
     const models = searchModels(carName);
     let cardPerPage = 4;
 
     return (
-        <div className=" h-full relative flex flex-col gap-7  my-8 mx-20">
-            <div className="absolute left-0 top-0">전체모델({ models.length })</div>
+        <div ref={elementRef} className="h-full relative flex flex-col gap-7  my-8 mx-20 overflow-hidden">
+            <div className="absolute left-0 top-0">전체모델({models.length})</div>
             <div className="flex gap-2 justify-center items-center">
-                {Array.from({ length: Math.ceil(models.length/cardPerPage) }).map((_, index) => (
+                {Array.from({ length: Math.ceil(models.length / cardPerPage) }).map((_, index) => (
                     <div
-                    key={index}
-                    className={`w-3 h-3 rounded-full ${
-                        index === pageNum ? "bg-blue-500" : "bg-gray-300"
-                    }`}
-                    onClick={()=>{setPageNum(index)}}
+                        key={index}
+                        className={`w-3 h-3 rounded-full ${index === pageNum ? "bg-blue-500" : "bg-gray-300"
+                            }`}
+                        onClick={() => { setPageNum(index) }}
                     ></div>
                 ))}
             </div>
-            <div className="flex gap-x-7 justify-center items-center">
-                {models.slice(pageNum*cardPerPage, (pageNum+1)*cardPerPage).map((carModel,i )=>{
+            <div className='flex gap-x-7 items-center transform transition duration-300 ease-in-out'
+                style={{ transform: `translateX(${-(rectWidth + 28) * pageNum}px)` }}>
+                {models.map((carModel, i) => {
                     return (
-                        <ModelCard key={i} carModel={carModel}/>
+                        <ModelCard key={i} carModel={carModel} cardWidth={rectWidth / cardPerPage} />
                     )
                 })}
             </div>

--- a/mycar/src/components/ModelSelect.jsx
+++ b/mycar/src/components/ModelSelect.jsx
@@ -8,9 +8,9 @@ export default function ModelSelect(props) {
             <div className='w-full px-28 flex justify-around'>
                 {Object.values(Category).map((value, i) => (
                     <button
-                        className={classNames('min-w-max px-2 py-1', {
-                            'text-blue-600': props.category === value,
-                        })}
+                        className={classNames('min-w-max px-2 py-1', 
+                            props.category === value && 'text-blue-600',
+                        )}
                         key={i}
                         onClick={() => {
                             props.setCate(value);

--- a/mycar/src/components/ModelSelect.jsx
+++ b/mycar/src/components/ModelSelect.jsx
@@ -9,7 +9,7 @@ export default function ModelSelect(props) {
                 {Object.values(Category).map((value, i) => (
                     <button
                         className={classNames('min-w-max px-2 py-1', 
-                            props.category === value && 'text-blue-600',
+                            props.category === value && 'text-textBlue',
                         )}
                         key={i}
                         onClick={() => {

--- a/mycar/src/components/ModelSelect.jsx
+++ b/mycar/src/components/ModelSelect.jsx
@@ -3,7 +3,7 @@ import { Category } from '../datas/carInfo';
 
 export default function ModelSelect(props) {
   return (
-    <div className='w-full h-20 flex justify-center items-center max-w-6xl'>
+    <div className='w-full h-16 flex justify-center items-center max-w-6xl flex-shrink-0'>
       <h2 className='min-w-max font-bold'>모델 선택</h2>
       <div className='w-full px-28 flex justify-around'>
         {Object.values(Category).map((value, i) => (

--- a/mycar/src/components/ModelSelect.jsx
+++ b/mycar/src/components/ModelSelect.jsx
@@ -2,24 +2,24 @@ import classNames from 'classnames';
 import { Category } from '../datas/carInfo';
 
 export default function ModelSelect(props) {
-  return (
-    <div className='w-full h-16 flex justify-center items-center max-w-6xl flex-shrink-0'>
-      <h2 className='min-w-max font-bold'>모델 선택</h2>
-      <div className='w-full px-28 flex justify-around'>
-        {Object.values(Category).map((value, i) => (
-          <button
-            className={classNames('min-w-max px-2 py-1', {
-              'text-blue-600': props.category === value,
-            })}
-            key={i}
-            onClick={() => {
-              props.setCate(value);
-            }}
-          >
-            {value}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
+    return (
+        <div className='w-full h-16 flex justify-center items-center max-w-6xl flex-shrink-0'>
+            <h2 className='min-w-max font-bold'>모델 선택</h2>
+            <div className='w-full px-28 flex justify-around'>
+                {Object.values(Category).map((value, i) => (
+                    <button
+                        className={classNames('min-w-max px-2 py-1', {
+                            'text-blue-600': props.category === value,
+                        })}
+                        key={i}
+                        onClick={() => {
+                            props.setCate(value);
+                        }}
+                    >
+                        {value}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
 }

--- a/mycar/src/components/OptionPageHeader.jsx
+++ b/mycar/src/components/OptionPageHeader.jsx
@@ -1,14 +1,16 @@
 import classNames from "classnames";
+import { useNavigate } from "react-router-dom";
 
 export default function OptionPageHeader({ step, setStep }) {
+    const navigate = useNavigate();
     return (
         <header className="w-full flex flex-col justify-between bg-primary px-12 pt-2 gap-4">
             <div className="w-full flex justify-between items-center">
                 <img src="https://www.hyundai.com/static/images/logo_black.png"></img>
-                <div className="flex gap-2 items-center">
+                <button className="flex gap-2 items-center" onClick={()=>{navigate(-1,{replace:true} );}}>
                     <h4>종료</h4>
                     <img src="https://www.hyundai.com/static/images/blit_end.png"></img>
-                </div>
+                </button>
             </div>
             <div className="flex gap-12 text-xl text-gray-500 font-bold">
                 <div className={classNames("relative flex justify-between gap-6 pb-6", { 'step text-black': step === 1, })} onClick={() => setStep(1)}>

--- a/mycar/src/components/OptionPageHeader.jsx
+++ b/mycar/src/components/OptionPageHeader.jsx
@@ -1,0 +1,26 @@
+import classNames from "classnames";
+
+export default function OptionPageHeader({ step, setStep }) {
+    return (
+        <header className="w-full flex flex-col justify-between bg-primary px-12 pt-2 gap-4">
+            <div className="w-full flex justify-between items-center">
+                <img src="https://www.hyundai.com/static/images/logo_black.png"></img>
+                <div className="flex gap-2 items-center">
+                    <h4>종료</h4>
+                    <img src="https://www.hyundai.com/static/images/blit_end.png"></img>
+                </div>
+            </div>
+            <div className="flex gap-12 text-xl text-gray-500 font-bold">
+                <div className={classNames("relative flex justify-between gap-6 pb-6", { 'step text-black': step === 1, })} onClick={() => setStep(1)}>
+                    <p>01</p>
+                    <p>모델 선택</p>
+                </div>
+                <hr className="h-8 bg-black opacity-30" style={{ width: '1px' }} />
+                <div className={classNames("relative flex justify-between gap-6 pb-6", { 'step text-black': step === 2 })} onClick={() => setStep(2)}>
+                    <p>02</p>
+                    <p>내 차 만들기</p>
+                </div>
+            </div>
+        </header >
+    )
+}

--- a/mycar/src/datas/carDetailModel.js
+++ b/mycar/src/datas/carDetailModel.js
@@ -1,0 +1,137 @@
+export const carDetailModels = [
+    {
+        carName: "아반떼",
+        detailModels: [
+            {
+                modelName: "Smart",
+                price: "19,940,000 원",
+                imageSrc: "https://www.hyundai.com//contents/vr360/CN17/trim/RB.png"
+            },
+            {
+                modelName: "Modern",
+                price: "23,260,000 원",
+                imageSrc: "https://www.hyundai.com//contents/vr360/CN17/trim/RD.png"
+            },
+            {
+                modelName: "N Line Modern",
+                price: "24,460,000 원",
+                imageSrc: "https://www.hyundai.com//contents/vr360/CN17/trim/RF.png"
+            },
+            {
+                modelName: "Inspiration",
+                price: "26,990,000 원",
+                imageSrc: "https://www.hyundai.com//contents/vr360/CN17/trim/RG.png"
+            },
+            {
+                modelName: "N Line Inspiration",
+                price: "27,880,000 원",
+                imageSrc: "https://www.hyundai.com//contents/vr360/CN17/trim/RK.png"
+            }
+        ],
+    },
+    {
+        carName: "쏘나타",
+        detailModels: [
+            {
+                modelName: "Premium",
+                price: "27,180,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/sonata/trim/premium.png",
+            },
+            {
+                modelName: "Premium Plus",
+                price: "29,210,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/sonata/trim/premium_plus.png",
+            },
+            {
+                modelName: "Inspiration",
+                price: "34,210,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/sonata/trim/inspiration.png",
+            },
+        ],
+    },
+    {
+        carName: "그랜저",
+        detailModels: [
+            {
+                modelName: "Premium",
+                price: "37,890,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/grandeur/trim/premium.png",
+            },
+            {
+                modelName: "Exclusive",
+                price: "41,320,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/grandeur/trim/exclusive.png",
+            },
+            {
+                modelName: "Calligraphy",
+                price: "45,370,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/grandeur/trim/calligraphy.png",
+            },
+        ],
+    },
+    {
+        carName: "투싼",
+        detailModels: [
+            {
+                modelName: "Modern",
+                price: "25,770,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/tucson/trim/modern.png",
+            },
+            {
+                modelName: "Inspiration",
+                price: "31,350,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/tucson/trim/inspiration.png",
+            },
+        ],
+    },
+    {
+        carName: "팰리세이드",
+        detailModels: [
+            {
+                modelName: "Exclusive",
+                price: "38,470,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/palisade/trim/exclusive.png",
+            },
+            {
+                modelName: "Prestige",
+                price: "42,630,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/palisade/trim/prestige.png",
+            },
+            {
+                modelName: "Calligraphy",
+                price: "47,750,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/palisade/trim/calligraphy.png",
+            },
+        ],
+    },
+    {
+        carName: "아이오닉 5",
+        detailModels: [
+            {
+                modelName: "Exclusive",
+                price: "52,000,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/ioniq5/trim/exclusive.png",
+            },
+            {
+                modelName: "Prestige",
+                price: "57,000,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/ioniq5/trim/prestige.png",
+            },
+        ],
+    },
+    {
+        carName: "스타리아",
+        detailModels: [
+            {
+                modelName: "Tourer",
+                price: "28,230,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/staria/trim/tourer.png",
+            },
+            {
+                modelName: "Cargo",
+                price: "25,240,000 원",
+                imageSrc: "https://www.hyundai.com/kr/ko/vehicles/staria/trim/cargo.png",
+            },
+        ],
+    },
+];

--- a/mycar/src/datas/carInfo.js
+++ b/mycar/src/datas/carInfo.js
@@ -18,6 +18,13 @@ export const carThumbnails = [
       'https://www.hyundai.com/contents/repn-car/side-45/porter2-live-fish-carrier-24my-45side.png',
   },
   {
+    carType: Category.SEDAN,
+    carName: '아반떼',
+    carPrice: '1,964만원~',
+    imageLink:
+      'https://www.hyundai.com/contents/repn-car/side-45/avante-25my-45side.png',
+  },
+  {
     carType: Category.N,
     carName: '아반떼 N',
     carPrice: '3,100만원~',

--- a/mycar/src/index.css
+++ b/mycar/src/index.css
@@ -5,3 +5,39 @@
 button:hover {
   cursor: pointer;
 }
+
+@layer utilities {
+  .step::after {
+    border-bottom-color: rgb(255, 255, 255);
+    /* 하단 테두리 색: 흰색 */
+    border-bottom-style: solid;
+    /* 하단 테두리 스타일: 실선 */
+    border-bottom-width: 10px;
+    /* 하단 테두리 두께: 10px */
+
+    border-left-color: rgba(0, 0, 0, 0);
+    /* 왼쪽 테두리 색: 투명 */
+    border-left-style: solid;
+    /* 왼쪽 테두리 스타일: 실선 */
+    border-left-width: 10px;
+    /* 왼쪽 테두리 두께: 10px */
+
+    border-right-color: rgba(0, 0, 0, 0);
+    /* 오른쪽 테두리 색: 투명 */
+    border-right-style: solid;
+    /* 오른쪽 테두리 스타일: 실선 */
+    border-right-width: 10px;
+    /* 오른쪽 테두리 두께: 10px */
+
+    width: 1px;
+    /* 요소의 너비 */
+    height: 1px;
+    /* 요소의 높이 */
+    position: absolute;
+    left: 50%; /* 가로 중앙으로 이동 */
+    bottom: 0px;
+    /* 절대 위치 지정 */
+    content: "";
+    /* 가상 요소 내용 없음 */
+  }
+}

--- a/mycar/src/main.jsx
+++ b/mycar/src/main.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
-import ReactDOM from "react-dom";
-import { createRoot } from 'react-dom/client'
+import ReactDOM from "react-dom/client";
 import './index.css'
 import App from './App.jsx'
 

--- a/mycar/src/main.jsx
+++ b/mycar/src/main.jsx
@@ -1,9 +1,10 @@
 import { StrictMode } from 'react'
+import ReactDOM from "react-dom";
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
-createRoot(document.getElementById('root')).render(
+ReactDOM.createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/mycar/src/pages/SelectModel.jsx
+++ b/mycar/src/pages/SelectModel.jsx
@@ -4,8 +4,10 @@ import ModelSelect from '../components/ModelSelect';
 import { carThumbnails, Category } from '../datas/carInfo';
 import { Link } from 'react-router-dom';
 
+const initialCategory = Category.EV;
+
 export default function SelectModel () {
-    const [category, setCate] = useState(Category.EV);
+    const [category, setCate] = useState(initialCategory);
 
     return (
         <div className='h-dvh w-full min-w-96 flex flex-col'>
@@ -22,9 +24,8 @@ export default function SelectModel () {
         <hr className='h-1 w-full'></hr>
         <div className='grid grid-cols-2 md:grid-cols-4 gap-x-5 gap-y-10 py-10 px-10 lg:px-52'>
           {carThumbnails.filter((car) => car.carType === category).map((car, i) => (
-            <Link to={`/select-option/${car.carName}`}>
+            <Link key={i} to={`/select-option/${car.carName}`}>
               <CarThumbnail
-                key={i}
                 imageLink={car.imageLink}
                 carName={car.carName}
                 carPrice={car.carPrice}

--- a/mycar/src/pages/SelectModel.jsx
+++ b/mycar/src/pages/SelectModel.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import CarThumbnail from '../components/CarThumbnail';
+import ModelSelect from '../components/ModelSelect';
+import { carThumbnails, Category } from '../datas/carInfo';
+import { Link } from 'react-router-dom';
+
+export default function SelectModel () {
+    const [category, setCate] = useState(Category.EV);
+
+    return (
+        <div className='h-dvh w-full min-w-96 flex flex-col'>
+      <header className='h-2/5 bg-primary p-10 pb-0 flex-shrink-0'>
+        <div className='w-full h-full bg-secondary flex flex-col justify-center items-center gap-8'>
+          <h1 className='text-6xl font-bold'>내 차 만들기</h1>
+          <h1 className='text-base font-normal'>
+            내가 타고 싶은 나만의 차를 만들어 보세요.
+          </h1>
+        </div>
+      </header>
+      <main className='w-full flex flex-col items-center'>
+        <ModelSelect setCate={setCate} category={category} />
+        <hr className='h-1 w-full'></hr>
+        <div className='grid grid-cols-2 md:grid-cols-4 gap-x-5 gap-y-10 py-10 px-10 lg:px-52'>
+          {carThumbnails.filter((car) => car.carType === category).map((car, i) => (
+            <Link to={`/select-option/${car.carName}`}>
+              <CarThumbnail
+                key={i}
+                imageLink={car.imageLink}
+                carName={car.carName}
+                carPrice={car.carPrice}
+              />
+            </Link>
+          ))}
+        </div>
+      </main>
+    </div>
+    )
+}

--- a/mycar/src/pages/SelectOption.jsx
+++ b/mycar/src/pages/SelectOption.jsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import OptionPageHeader from "../components/OptionPageHeader";
 import { useState } from "react";
 import ModelList from "../components/ModelList";
+import { AnimatePresence, delay, easeIn, easeInOut, easeOut, motion } from "motion/react"
 
 export default function SelectOption() {
     const { carName } = useParams();
@@ -10,7 +11,23 @@ export default function SelectOption() {
     return (
         <div>
             <OptionPageHeader step={step} setStep={setStep} />
-            <ModelList carName={carName} />
+            <AnimatePresence initial={false} mode="wait">
+                {step === 1
+                    ? <motion.div
+                        key={step}
+                        initial={{ x: 0, y: 400, opacity: 0 }}
+                        animate={{ y: 0, opacity: 1, transition: { duration: 0.4, ease: easeOut} }}
+                        exit={{ x: -700, opacity: 0, transition: { duration: 0.3, ease: easeOut} }}>
+                        <ModelList carName={carName} />
+                    </motion.div>
+                    : <motion.div
+                        key={step}
+                        initial={{ x: 500, y: 0, opacity: 0 }}
+                        animate={{ x: 0, opacity: 1, transition: { duration: 0.4, ease: easeOut} }}
+                        exit={{ x: -700, opacity: 0, transition: { duration: 0.3, ease: easeOut} }}>
+                        <ModelList carName={carName} />
+                    </motion.div>}
+            </AnimatePresence>
         </div>
     )
 }

--- a/mycar/src/pages/SelectOption.jsx
+++ b/mycar/src/pages/SelectOption.jsx
@@ -1,6 +1,7 @@
 import { useParams } from "react-router-dom";
 import OptionPageHeader from "../components/OptionPageHeader";
 import { useState } from "react";
+import ModelList from "../components/ModelList";
 
 export default function SelectOption() {
     const { carName } = useParams();
@@ -9,6 +10,7 @@ export default function SelectOption() {
     return (
         <div>
             <OptionPageHeader step={step} setStep={setStep} />
+            <ModelList carName={carName} />
         </div>
     )
 }

--- a/mycar/src/pages/SelectOption.jsx
+++ b/mycar/src/pages/SelectOption.jsx
@@ -1,0 +1,14 @@
+import { useParams } from "react-router-dom";
+import OptionPageHeader from "../components/OptionPageHeader";
+import { useState } from "react";
+
+export default function SelectOption() {
+    const { carName } = useParams();
+    const [step, setStep] = useState(1);
+
+    return (
+        <div>
+            <OptionPageHeader step={step} setStep={setStep} />
+        </div>
+    )
+}

--- a/mycar/tailwind.config.js
+++ b/mycar/tailwind.config.js
@@ -10,7 +10,8 @@ export default {
         primary:"#E5DCD3",
         secondary:"#F1EDE9",
         thirdary:"#F5F3F2",
-        buttonBlue:"#002C5F" 
+        buttonBlue:"#002C5F",
+        textBlue:"#007fa8"
       }
     },
   },


### PR DESCRIPTION
## 주요 작업
- 페이지 라우팅 구현 완료
- 페이지 2-1에 필요한 컴포넌트(헤더, 모델카드, 모델카드 캐러셀) 구현 완료
- 캐러셀 전환 애니메이션, 페이지 전환 애니메이션 구현 완료
https://drive.google.com/file/d/1XMU0rqB0EFvMb1YaFrfnG7_bAmg4ccBP/view?usp=drive_link

## 학습 키워드
ReactRoute, Transform, Motion 라이브러리, useRef, useEffect

## 고민과 해결과정
케러셀 전환 애니메이션 로직이 고민이었음 -> useRef로 실제 DOM의 가로길이를 참조해서 캐러셀이 이동해야하는 x축 거리를 계산하고 transform을 사용해서 해결함. 브라우저 resize 이벤트에도 리스너를 달아 캐러셀의 이동거리를 동적으로 계산할 수 있도록 함.