### PR TITLE
[황유란 이지훈] - 차종선택 페이지 구현

### DIFF
--- a/my-car/eslint.config.js
+++ b/my-car/eslint.config.js
@@ -28,6 +28,7 @@ export default [
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/no-explicit-any': 'error',
       'no-console': 'warn',
     },
   },

--- a/my-car/src/App.css
+++ b/my-car/src/App.css
@@ -1,4 +1,4 @@
-#root {
+/* #root {
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
@@ -39,4 +39,4 @@
 
 .read-the-docs {
   color: #888;
-}
+} */

--- a/my-car/src/assets/data/car.json
+++ b/my-car/src/assets/data/car.json
@@ -2,24 +2,28 @@
   "아이오닉6": {
     "2WD": [
       {
+        "carType": "아이오닉6",
         "name": "E-Value +(스탠다드) 18인치",
         "price": "49,450,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "2WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "Exclusive(스탠다드) 18인치",
         "price": "52,090,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "2WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "E-LITE(롱레인지) 18인치",
         "price": "53,300,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "2WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "E-LITE(롱레인지) 18인치",
         "price": "53,300,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
@@ -28,44 +32,58 @@
     ],
     "4WD": [
       {
+        "carType": "아이오닉6",
         "name": "E-LITE(롱레인지) 18인치",
         "price": "55,770,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "4WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "Exclusive(롱레인지) 18인치",
         "price": "59,400,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "4WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "Exclusive(롱레인지) 20인치",
         "price": "59,990,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "4WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "Exclusive+(롱레인지) 18인치",
         "price": "61,190,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "4WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "Exclusive+(롱레인지) 20인치",
         "price": "61,780,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "4WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "Prestige(롱레인지) 18인치",
         "price": "64,980,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "4WD"
       },
       {
+        "carType": "아이오닉6",
         "name": "Prestige(롱레인지) 20인치",
         "price": "65,570,000 원",
+        "imgUrl": "/src/assets/standard_car_img.png",
+        "wd": "4WD"
+      },
+      {
+        "carType": "아이오닉6",
+        "name": "Prestige(롱레인지) 22인치",
+        "price": "67,570,000 원",
         "imgUrl": "/src/assets/standard_car_img.png",
         "wd": "4WD"
       }

--- a/my-car/src/assets/data/carModelList.json
+++ b/my-car/src/assets/data/carModelList.json
@@ -1,0 +1,193 @@
+{
+  "수소/전기차": [
+    {
+      "name": "아이오닉5",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "넥쏘",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "코나 Electric",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "아이오닉 6",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "아이오닉5",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "넥쏘",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "코나 Electric",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ],
+  "N": [
+    {
+      "name": "아반떼",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "소나타",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "그랜저",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "팰리세이드",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ],
+  "승용": [
+    {
+      "name": "아반떼",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "소나타",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "그랜저",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "팰리세이드",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ],
+  "SUV": [
+    {
+      "name": "아반떼",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "소나타",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "그랜저",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "팰리세이드",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ],
+  "MPV": [
+    {
+      "name": "아반떼",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "소나타",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "그랜저",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "팰리세이드",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ],
+  "소형트럭 & 택시": [
+    {
+      "name": "아반떼",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "소나타",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "그랜저",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "팰리세이드",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ],
+  "트럭": [
+    {
+      "name": "아반떼",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "소나타",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "그랜저",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "팰리세이드",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ],
+  "버스": [
+    {
+      "name": "아반떼",
+      "price": "2,990만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "소나타",
+      "price": "6,950만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "그랜저",
+      "price": "4,142만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    },
+    {
+      "name": "팰리세이드",
+      "price": "4,695만원 ~",
+      "img": "/src/assets/standard_car_img.png"
+    }
+  ]
+}

--- a/my-car/src/components/header.tsx
+++ b/my-car/src/components/header.tsx
@@ -1,22 +1,88 @@
 import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface HeaderProps {
   currentCarModel: string;
   currentStep: number;
 }
 
+const categoryList = ['수소/전기차', 'N', '승용', 'SUV', 'MPV', '소형트럭 & 택시', '트럭', '버스'];
+
 export function Header({ currentCarModel }: HeaderProps) {
+  const [isMocalOpen, setIsModalOpen] = useState(false);
+  const [currentCarType, setCurrentCarType] = useState('수소/전기차');
+  const [carModelList, setCarModelList] = useState({});
+  const Navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch('/src/assets/data/carModelList.json');
+        const data = await response.json();
+        setCarModelList(data);
+      } catch (error) {
+        alert(error);
+      }
+    };
+    fetchData();
+  }, []);
+
   return (
-    <StyledHeader>
-      <HeaderTop>
-        <h1>HYUNDAI</h1>
-        <h2> | {currentCarModel}</h2>
-      </HeaderTop>
-      <HeaderBottom>
-        <button>model 선택</button>
-        <button>내차 만들기</button>
-      </HeaderBottom>
-    </StyledHeader>
+    <>
+      <StyledHeader>
+        <HeaderTop>
+          <h1>HYUNDAI</h1>
+          <HeaderButton onClick={() => setIsModalOpen(!isMocalOpen)}>
+            {' '}
+            | {currentCarModel}{' '}
+          </HeaderButton>
+        </HeaderTop>
+        <HeaderBottom>
+          <HeaderButton>model 선택</HeaderButton>
+          <HeaderButton>내차 만들기</HeaderButton>
+        </HeaderBottom>
+      </StyledHeader>
+      {isMocalOpen && (
+        <>
+          <ModalBackground />
+
+          <CarSelectModal>
+            <Tabbar>
+              {categoryList.map((item) => (
+                <CarSelectModalTabbar
+                  key={item}
+                  $isSelected={currentCarType === item}
+                  onClick={() => {
+                    setCurrentCarType(item);
+                  }}
+                >
+                  {item}
+                </CarSelectModalTabbar>
+              ))}
+            </Tabbar>
+
+            <Wrapper>
+              <TabbarItemContainer>
+                {carModelList[currentCarType].map((item) => (
+                  <TabbarItem
+                    key={item.name}
+                    onClick={() => {
+                      setIsModalOpen(false);
+                      Navigate('/'); // 사실 이동 안함 ㅋㅋ
+                    }}
+                  >
+                    <img src={item.img} alt="car" width={'160px'} />
+                    <h4>{item.name}</h4>
+                    <p>{item.price}</p>
+                  </TabbarItem>
+                ))}
+              </TabbarItemContainer>
+            </Wrapper>
+          </CarSelectModal>
+        </>
+      )}
+    </>
   );
 }
 
@@ -39,8 +105,77 @@ const HeaderTop = styled.div`
 
 const HeaderBottom = styled.div`
   display: flex; // 플렉스
-  gap: 16px;
+  gap: 40px;
   align-items: center; // 가운데 정렬
-  padding: 0 8px; // 패딩
+  padding: 0 8px 0 40px; // 패딩
   height: 50%; // 높이
+`;
+
+const HeaderButton = styled.button`
+  background: none;
+  border: none;
+  font-size: 20px;
+  font-weight: bold;
+`;
+
+const ModalBackground = styled.div`
+  position: fixed;
+  top: 69px;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 2;
+`;
+
+const CarSelectModal = styled.div`
+  position: fixed;
+  top: 69px;
+  height: 300px;
+  width: 100vw;
+  background-color: #fff;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 60px;
+`;
+
+const Tabbar = styled.div`
+  display: flex;
+`;
+
+const CarSelectModalTabbar = styled.div<{ $isSelected: boolean }>`
+  width: 140px;
+  height: 40px;
+  background-color: ${(props) => (props.$isSelected ? '#fff' : '#444')};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${(props) => (props.$isSelected ? '#444' : '#fff')};
+  cursor: pointer;
+  transition: all 0.2s ease;
+`;
+
+const TabbarItemContainer = styled.div`
+  display: flex;
+  gap: 20px;
+  align-items: center;
+`;
+
+const TabbarItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
+  height: 70%;
+  width: 240px;
+  &: hover {
+    background-color: #f6f3f2;
+  }
+`;
+
+const Wrapper = styled.div`
+  height: 100%;
+  display: flex;
 `;

--- a/my-car/src/index.css
+++ b/my-car/src/index.css
@@ -1,4 +1,4 @@
-:root {
+/* :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -65,4 +65,4 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
-}
+} */

--- a/my-car/src/pages/modelselection/components/BoxList.tsx
+++ b/my-car/src/pages/modelselection/components/BoxList.tsx
@@ -34,7 +34,9 @@ export const BoxList = ({ list }) => {
                 <img src={DoorHandle} />
               </li>
             </ArticleOption>
-            <PrimaryButton onClick={() => router.navigate('/options')}>내 차 만들기</PrimaryButton>
+            <PrimaryButton onClick={() => router.navigate(`/options/${item.carType}`)}>
+              내 차 만들기
+            </PrimaryButton>
           </Article>
         ))}
       </ArticleContainer>

--- a/my-car/src/pages/modelselection/components/BoxListSlide.tsx
+++ b/my-car/src/pages/modelselection/components/BoxListSlide.tsx
@@ -15,29 +15,32 @@ export const BoxListSlide = ({ is2WD }: { is2WD: boolean }) => {
         if (is2WD === true) wd = '2WD';
         setCarData(data['아이오닉6'][wd]);
       } catch (error) {
-        console.error('Error fetching car data:', error);
+        alert(error);
       }
     };
-
+    setCurrentPage(0);
     fetchData();
   }, [is2WD]);
 
   const totalPages = Math.ceil(carData.length / 4);
-  const itemsPerPage = 4; // 페이지당 보여줄 아이템 개수
 
   const [currentPage, setCurrentPage] = useState(0); // 현재 페이지 상태
-  const currentData = carData.slice(currentPage * itemsPerPage, (currentPage + 1) * itemsPerPage);
 
   return (
     <BoxListSlideWrapper>
       <BoxListNav>
         {Array.from({ length: totalPages }).map((_, index) => (
           <li key={index}>
-            <NavButton onClick={() => setCurrentPage(0)} />
+            <NavButton isSelected={index === currentPage} onClick={() => setCurrentPage(index)} />
           </li>
         ))}
       </BoxListNav>
-      <BoxList list={currentData} />
+
+      <SlideContainer>
+        <SlideWrapper currentPage={currentPage}>
+          <BoxList list={carData} />
+        </SlideWrapper>
+      </SlideContainer>
     </BoxListSlideWrapper>
   );
 };
@@ -60,10 +63,22 @@ const BoxListNav = styled.ul`
   z-index: 2;
 `;
 
-const NavButton = styled.button`
+const NavButton = styled.button<{ isSelected: boolean }>`
   width: 12px;
   height: 12px;
   border-radius: 6px;
   padding: 0;
-  background-color: #ddd;
+  background-color: ${({ isSelected }) => (isSelected ? '#007fa8' : '#ddd')};
+`;
+
+const SlideContainer = styled.div`
+  overflow: hidden;
+  width: 100%;
+  max-width: calc(350px * 4 + 16px * 3);
+`;
+
+const SlideWrapper = styled.div<{ currentPage: number }>`
+  display: flex;
+  transform: translateX(-${(props) => props.currentPage * 100}%);
+  transition: transform 0.5s ease-in-out;
 `;

--- a/my-car/src/pages/modelselection/components/FilterList.tsx
+++ b/my-car/src/pages/modelselection/components/FilterList.tsx
@@ -45,7 +45,7 @@ const WdSelectTitle = styled.p`
   font-weight: 700;
 `;
 
-const WdSelectButton = styled.button`
+const WdSelectButton = styled.button<{ isSelected: boolean }>`
   border-radius: 0;
   background-color: ${(props) => (props.isSelected ? '#007fa8' : '#fff')};
   color: ${(props) => (props.isSelected ? '#fff' : '#000')};

--- a/my-car/src/pages/option.tsx
+++ b/my-car/src/pages/option.tsx
@@ -1,3 +1,14 @@
+import { React } from 'react';
+import { Header } from '../components/header';
+import { useParams } from 'react-router-dom';
+
 export default function Option() {
-  return <div>option</div>;
+  const { model } = useParams();
+
+  return (
+    <>
+      <Header currentCarModel={model} currentStep={1} />
+      <></>
+    </>
+  );
 }

--- a/my-car/src/routes/index.tsx
+++ b/my-car/src/routes/index.tsx
@@ -6,7 +6,7 @@ import Option from '../pages/option.tsx';
 
 export const routes = {
   modelSelection: '/',
-  options: '/options',
+  options: '/options/:model',
   done: '/done',
 };
 


### PR DESCRIPTION

## 주요 작업
1. 헤더 내부에 차종선택 기능 추가 
2. 모델 선택 리스트 전환 기능 및 애니메이션 추가 
3. 옵션 페이지에 동적 세그먼트 방식을 통한 라우팅 추가

## 학습 키워드
1. 변수명 을 잘하자
2. 동적 세그먼트 
3. state 를 이용하여 컨디셔널 style 적용 및 props 속성 이용

## 고민과 해결과정

+ 모델 선택 페이지에서 내 차 만들기 페이지로 넘어갈때, header 에 표시될 차종을 전달해줘야 하는데 , 이걸 동적 세그먼트를 통해 전달해 주었다.
+ 원래는 , 4개씩 자른 데이터를 전달후 리스트 전환을 해줬는데, 이렇게 구현하니 리스트 페이지 전환시 데이터가 즉각적으로 사라지기 때문에 애니메이션을 자연스럽게 적용하는데에 문제가 있었다. 해서 , 데이터를 자르지 않고 모든 데이터를 가지고 온후 4개 만큼만 보이게 구현하여, 좌우로 움직이는 애니메이션을 자연스럽게 적용할수 있었다.